### PR TITLE
prevent RangeError when no columns present

### DIFF
--- a/js/dataTables.buttons.js
+++ b/js/dataTables.buttons.js
@@ -1415,7 +1415,7 @@ var _exportData = function ( dt, inOpts )
 		.render( config.orthogonal )
 		.toArray();
 	var columns = header.length;
-	var rows = cells.length / columns;
+	var rows = columns > 0 ? cells.length / columns : 0;
 	var body = new Array( rows );
 	var cellCounter = 0;
 


### PR DESCRIPTION
Currently if you have a data table which has no columns (edge use case I know) and you try to do something like export to csv, nothing appears to happen because of a division by 0. This at least lets the end user create an empty file.
